### PR TITLE
[TL][95861674] remove return false

### DIFF
--- a/jquery.leadservice.js
+++ b/jquery.leadservice.js
@@ -213,7 +213,6 @@ define(['jquery', 'jquery.cookie'], function($) {
       var submitLead = function() {
         caller = $(this);
         var status = 'fail';
-        if (this.beenSubmitted) return false;
         caller.trigger('LeadFormSubmitted');
         this.beenSubmitted = true;
         $.ajax({


### PR DESCRIPTION
We aren't allowing leads to be resubmitted on Rentals; this allows form resubmission.  Duplicate leads should be handled in the backend.  We are in the process of `feature flipping leads v3` on Rentals, so this is a temporary fix.  

[Story](https://www.pivotaltracker.com/story/show/95861674)
